### PR TITLE
Recuperar senha - mensagem de erro para email invalido

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -7,7 +7,13 @@ class PasswordResetsController < ApplicationController
   end
 
   def create
-    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    email = params[:password_reset][:email].downcase
+    if email.blank? || email !~ VALID_EMAIL_REGEX
+      flash.now[:alert] = 'email inválido'
+      render :new and return
+    end
+
+    @user = User.find_by(email: email)
     if @user&.activated?
       @user.create_reset_digest
       @user.send_password_reset_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,6 @@
 class User < ApplicationRecord
   PHOTO_WIDTH = 400
   PHOTO_HEIGHT = 480
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   UNACTIVATED_TTL = 30
 
   attr_accessor :activation_token, :reset_token, :crop_x, :crop_y, :crop_w,

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ AVAILABLE_LOCALES = {
 
 DEFAULT_LOCALE = :pt
 
+VALID_EMAIL_REGEX = /\A[\w+\-]+(?:\.[\w+\-]+)*@(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,6}\z/
+
 module Falae
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -549,6 +549,7 @@ en:
       body_end: 'If you did not request your password to be reset, please ignore this
                  email and your password will stay as it is.'
       invalid: Invalid reset password link.
+      invalid_email: Invalid email.
       subject: Password reset
       reset_password: Reset password
       verification: Please check your email for password reset instructions.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -550,6 +550,7 @@ pt:
                 e sua senha continuará a mesma.'
       expired_token: Link de alteração de senha expirou.
       invalid: Link de alteração de senha inválido.
+      invalid_email: Email inválido.
       subject: Alteração de senha
       reset_password: Alterar senha
       valid_reset: Senha alterada com sucesso.


### PR DESCRIPTION
Adição de mensagem de erro quando usuário deixa um valor inválido no campo "email" na página de alterar/recuperar senha.

![recuperar-senha-casos-invalidos](https://github.com/falae-it-talent/falae/assets/3502320/ec362ad6-59c5-4968-b6d0-90af75c3e491)
